### PR TITLE
Add task descriptions for rake -T visibility

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,9 +11,13 @@ require "picoruby/build"
 MRUBY_CONFIG = MRuby::Build.mruby_config_path
 load MRUBY_CONFIG
 
+desc "Default task that runs all main tasks"
 task :default => :all
+
+desc "Build, flash, and monitor the ESP32 project"
 task :all => %w[build flash monitor]
 
+desc "Install dependencies and build mruby"
 task :setup do
   FileUtils.cd MRUBY_ROOT do
     sh "bundle install"
@@ -22,33 +26,40 @@ task :setup do
 end
 
 %w[esp32 esp32c3 esp32c6 esp32s3].each do |name|
+  desc "Setup environment for #{name} target"
   task "setup_#{name}" => %w[deep_clean setup] do
     sh "idf.py set-target #{name}"
   end
 end
 
+desc "Build the ESP32 project"
 task :build do
   sh "idf.py build"
 end
 
+desc "Flash the built firmware to ESP32"
 task :flash do
   sh "idf.py flash"
 end
 
+desc "Erase factory partition and flash firmware binary"
 task :flash_factory do
   sh "esptool.py -b 460800 erase_region 0x10000 0x100000"
   sh "esptool.py -b 460800 write_flash 0x10000 build/R2P2-ESP32.bin"
 end
 
+desc "Erase storage partition and flash storage binary"
 task :flash_storage do
   sh "esptool.py -b 460800 erase_region 0x110000 0x100000"
   sh "esptool.py -b 460800 write_flash 0x110000 build/storage.bin"
 end
 
+desc "Monitor ESP32 serial output"
 task :monitor do
   sh "idf.py monitor"
 end
 
+desc "Clean build artifacts"
 task :clean do
   sh "idf.py clean"
   FileUtils.cd MRUBY_ROOT do
@@ -58,6 +69,7 @@ task :clean do
   end
 end
 
+desc "Perform deep clean including ESP32 build repos"
 task :deep_clean => %w[clean] do
   sh "idf.py fullclean"
   rm_rf File.join(MRUBY_ROOT, "build/repos/esp32")


### PR DESCRIPTION
# Problem
Currently, running `rake -T` doesn't display any tasks because they lack descriptions. This makes it difficult for developers to discover and understand available tasks in the ESP32 development workflow.

# Solution
Added descriptive `desc` statements to all Rake tasks, including:
- Main workflow tasks (build, flash, monitor)
- Setup tasks for different ESP32 targets (esp32, esp32c3, esp32c6, esp32s3)
- Maintenance tasks (clean, deep_clean)
- Specialized tasks (flash_factory, flash_storage)

# Benefits
- Developers can now use `rake -T` to see all available tasks with clear descriptions
- Improves onboarding experience for new contributors
- Makes the development workflow more discoverable and self-documenting

# Testing
Run `rake -T` to verify all tasks are now listed with appropriate descriptions.