### PR TITLE
Expand the Flash factory area size to 2MB

### DIFF
--- a/partitions.csv
+++ b/partitions.csv
@@ -2,5 +2,5 @@
 # Note: if you have increased the bootloader size, make sure to update the offsets to avoid overlap
 nvs,      data, nvs,     0x9000,  0x6000,
 phy_init, data, phy,     0xf000,  0x1000,
-factory,  app,  factory, 0x10000, 1M,
+factory,  app,  factory, 0x10000, 2M,
 storage,  data, fat,     ,        1M,


### PR DESCRIPTION
Expand the Flash factory area size from 1MB to 2MB to enable future migration to MicroRuby

picoruby-filesystem-fat has been addressed in this Pull Request.
https://github.com/picoruby/picoruby/pull/250