### PR TITLE
Add release workflow for production branch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,7 @@ jobs:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: patch
           tag_prefix: ""
+          release_branches: "production,ci/release-workflow"
 
   build:
     needs: bump-version

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,113 @@
+name: Release
+
+on:
+  push:
+    branches:
+      - production
+      - ci/release-workflow
+
+jobs:
+  bump-version:
+    runs-on: ubuntu-latest
+    outputs:
+      new_tag: ${{ steps.tag.outputs.new_tag }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Bump version and push tag
+        id: tag
+        uses: mathieudutour/github-tag-action@v6.2
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          default_bump: patch
+          tag_prefix: ""
+
+  build:
+    needs: bump-version
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - target: esp32
+            vm_name: femtoruby
+            vm_flag: mrubyc
+            artifact_suffix: esp32-femtoruby
+            sdkconfig_defaults: sdkconfig.defaults
+          - target: esp32
+            vm_name: picoruby
+            vm_flag: mruby
+            artifact_suffix: esp32-picoruby
+            sdkconfig_defaults: sdkconfig.defaults
+          - target: esp32s3
+            vm_name: femtoruby
+            vm_flag: mrubyc
+            artifact_suffix: esp32s3-femtoruby
+            sdkconfig_defaults: sdkconfig.defaults
+          - target: esp32s3
+            vm_name: picoruby
+            vm_flag: mruby
+            artifact_suffix: esp32s3-picoruby
+            sdkconfig_defaults: sdkconfig.defaults
+          - target: esp32c3
+            vm_name: femtoruby
+            vm_flag: mrubyc
+            artifact_suffix: esp32c3-femtoruby
+            sdkconfig_defaults: sdkconfig.defaults
+          - target: esp32c3
+            vm_name: picoruby
+            vm_flag: mruby
+            artifact_suffix: esp32c3-picoruby
+            sdkconfig_defaults: sdkconfig.defaults
+          - target: esp32s3
+            vm_name: femtoruby
+            vm_flag: mrubyc
+            artifact_suffix: esp32s3-usb_console-femtoruby
+            sdkconfig_defaults: "sdkconfig.defaults;sdkconfigs/usb_console"
+          - target: esp32s3
+            vm_name: picoruby
+            vm_flag: mruby
+            artifact_suffix: esp32s3-usb_console-picoruby
+            sdkconfig_defaults: "sdkconfig.defaults;sdkconfigs/usb_console"
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          submodules: recursive
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.4'
+      - name: Bundle install
+        run: bundle install
+        working-directory: ./components/picoruby-esp32/picoruby
+      - name: Build PicoRuby
+        run: rake
+        working-directory: ./components/picoruby-esp32/picoruby
+      - name: Build firmware
+        uses: espressif/esp-idf-ci-action@v1
+        with:
+          esp_idf_version: v5.5.1
+          target: ${{ matrix.target }}
+          path: '.'
+          command: SDKCONFIG_DEFAULTS="${{ matrix.sdkconfig_defaults }}" idf.py build -DPICORB_VM=${{ matrix.vm_flag }}
+      - name: Rename artifact
+        run: cp build/R2P2-ESP32.bin R2P2-ESP32-${{ matrix.artifact_suffix }}.bin
+      - uses: actions/upload-artifact@v4
+        with:
+          name: firmware-${{ matrix.artifact_suffix }}
+          path: R2P2-ESP32-${{ matrix.artifact_suffix }}.bin
+
+  release:
+    needs: [bump-version, build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          pattern: firmware-*
+          merge-multiple: true
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ needs.bump-version.outputs.new_tag }}
+          name: Release ${{ needs.bump-version.outputs.new_tag }}
+          files: "*.bin"


### PR DESCRIPTION
## Summary

Add `.github/workflows/release.yml` to automate firmware release on push to `production` branch.

- Bumps semantic version tag (patch by default; minor/major via conventional commit messages)
- Builds 8 firmware variants in parallel:
  - `esp32` / `esp32s3` / `esp32c3` / `esp32s3-usb_console` × `femtoruby` / `picoruby`
- Uploads all `.bin` files to GitHub Releases

> **Note:** `ci/release-workflow` branch is temporarily added as a trigger for CI verification. It will be removed before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)