### PR TITLE
Auto-detect host CC/AR toolchain in setup task.

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,25 +137,13 @@ $ asdf local ruby 4.0.5
 $ rbenv local 4.0.5
 ```
 
-Set the C compiler (`CC`) and Archiver (`AR`) to the host toolchain.
-ESP-IDF's activation script may override these with cross-compilers.
+> **Note:** The setup task builds some host-side tools with the host (non-cross) toolchain. It is detected automatically even while ESP-IDF's cross toolchains are on PATH. If the detection picks a wrong compiler or archiver, override it with the `HOST_CC` / `HOST_AR` environment variables.
 
-```sh
-# macOS:
-$ export CC=/usr/bin/cc
-$ export AR=/usr/bin/ar
-# Linux:
-$ export CC=/usr/bin/gcc
-$ export AR=/usr/bin/ar
-```
-
-> **Tip:** You can manage all of the above environment variables in a `.envrc` file using [direnv](https://direnv.net/), so they are applied automatically whenever you enter the project directory.
+> **Tip:** You can manage the above environment variables in a `.envrc` file using [direnv](https://direnv.net/), so they are applied automatically whenever you enter the project directory.
 
 ```
 source ~/.espressif/tools/activate_idf_v5.5.4.sh
 PATH_add "$IDF_PATH/tools"
-export CC=/usr/bin/cc
-export AR=/usr/bin/ar
 ```
 
 ```sh

--- a/Rakefile
+++ b/Rakefile
@@ -17,11 +17,34 @@ task :default => :all
 desc "Build, flash, and monitor the ESP32 project"
 task :all => %w[build flash monitor]
 
+# Locate a host (non-cross) toolchain command. ESP-IDF's activation script
+# prepends its cross toolchains to PATH, so resolve the command against PATH
+# entries outside the ESP-IDF installation. HOST_CC / HOST_AR override the
+# detection.
+def find_host_tool(*names)
+  override = ENV["HOST_#{names.first.upcase}"]
+  return override if override
+
+  host_path = ENV['PATH'].split(File::PATH_SEPARATOR)
+                         .reject { |dir| dir.match?(/\.espressif|esp-idf/) }
+  names.each do |name|
+    host_path.each do |dir|
+      candidate = File.join(dir, name)
+      return candidate if File.file?(candidate) && File.executable?(candidate)
+    end
+  end
+  abort "Host toolchain `#{names.join('`/`')}` not found in PATH. Set HOST_#{names.first.upcase} to specify it."
+end
+
 desc "Install dependencies and build mruby"
 task :setup do
+  host_env = {
+    'CC' => find_host_tool('cc', 'gcc', 'clang'),
+    'AR' => find_host_tool('ar')
+  }
   FileUtils.cd MRUBY_ROOT do
     sh "bundle install"
-    sh "rake"
+    sh host_env, "rake"
   end
 end
 


### PR DESCRIPTION
- Previously, developers had to manually `export CC` / `AR` to the host toolchain before running `rake`, because ESP-IDF's activation script prepends its cross-compilers to `PATH`.
- The `setup` task now auto-detects the host `cc`/`gcc`/`clang` and `ar` by scanning `PATH` entries outside the ESP-IDF installation, and passes them as `CC`/`AR` only for the `rake` invocation inside `mrbgems`/mruby build.
- `HOST_CC` / `HOST_AR` environment variables can still be set to override detection if it picks the wrong tool.
- Updated README to reflect the simplified setup steps.