### PR TITLE
Document USE_WIFI build flag requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,33 @@ rake femtoruby:build
 
 See [Supported Devices](#supported-devices) for which VMs are available for each device.
 
+### Enabling WiFi (`USE_WIFI`)
+
+WiFi native code (`Network::WiFi` / `ESP32::WiFi`, and by extension `picoruby-socket`'s
+`TCPServer`/`TCPSocket` over WiFi) is **not** compiled in by default. To enable it, set the
+`USE_WIFI` environment variable before building:
+
+```sh
+$ export USE_WIFI=1
+$ rake build
+```
+
+This is required, for example, to use [picoruby-debug](https://github.com/yuuu/picoruby-debug)'s
+DAP remote debugging over WiFi.
+
+> **Note:** `USE_WIFI` is only read while CMake configures the project, not on every build. If
+> you already ran `rake setup_*` or `rake build` without `USE_WIFI` set, a plain
+> `USE_WIFI=1 rake build` will not pick it up and can fail with linker errors such as
+> `undefined reference to 'ESP32_WIFI_init'`. Force a reconfigure first:
+>
+> ```sh
+> $ export USE_WIFI=1
+> $ idf.py reconfigure
+> $ rake build
+> ```
+>
+> Alternatively, run `rake setup_*` again with `USE_WIFI=1` already exported.
+
 ### Flash and Monitor
 
 Flash the built image to your device:


### PR DESCRIPTION
## Summary

Part of the DAP remote-debugging implementation plan, **Phase 5a (ESP32 USE_WIFI verification)**: documents the `USE_WIFI` build flag needed to compile in `Network::WiFi`/`ESP32::WiFi` and, by extension, `picoruby-socket`'s `TCPServer`/`TCPSocket` over WiFi — a prerequisite for picoruby-debug's DAP remote debugging over WiFi.

- `README.md`: adds a new "Enabling WiFi (`USE_WIFI`)" section explaining:
  - `USE_WIFI=1 rake build` to enable WiFi native code.
  - That `USE_WIFI` is only read at CMake configure time, not on every build — an already-configured tree needs `idf.py reconfigure` (or a fresh `rake setup_*`) before `USE_WIFI=1 rake build` will actually pick it up, otherwise it fails with linker errors like `undefined reference to 'ESP32_WIFI_init'`.

## Test plan

- [x] On real ESP32-S3 hardware, `USE_WIFI=1 rake build` links successfully.
- [x] Confirmed `picoruby-socket`'s `TCPServer`/`TCPSocket` are present in the resulting binary.
- [x] Actual device flash/boot verification — not yet performed, pending go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)