### PR TITLE
Document WiFi-based DAP remote debugging, wire up picoruby-debug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@ dependencies.lock
 .envrc
 storage/home/*
 !storage/home/.keep
+!storage/home/dap_debug_sample.rb
 storage/etc/*
 !storage/etc/.keep
 .vscode/*

--- a/README.md
+++ b/README.md
@@ -198,6 +198,53 @@ DAP remote debugging over WiFi.
 >
 > Alternatively, run `rake setup_*` again with `USE_WIFI=1` already exported.
 
+### Remote debugging over WiFi (DAP)
+
+[picoruby-debug](https://github.com/yuuu/picoruby-debug) can serve the
+[Debug Adapter Protocol](https://microsoft.github.io/debug-adapter-protocol/) (DAP) over a plain
+TCP socket, so an editor (VS Code, Zed, ...) can set breakpoints, step, and inspect variables on
+the device remotely. It is **mruby-only** (the PicoRuby VM, not FemtoRuby/mruby/c), and it needs
+`picoruby-socket` to serve DAP — both are already wired into
+`components/picoruby-esp32/build_config/xtensa-esp-picoruby.rb` (and the `riscv-esp-picoruby.rb`
+equivalent).
+
+1. Build with WiFi enabled and the PicoRuby (mruby) VM:
+
+   ```sh
+   $ export USE_WIFI=1
+   $ idf.py reconfigure   # if the project was already configured without USE_WIFI, see above
+   $ rake picoruby:build
+   ```
+
+2. Connect the device to WiFi. Either let it auto-connect at boot (write
+   `storage/etc/network/wifi.yml` with `auto_connect: true`, e.g. via `rake gen_wifi_config`), or
+   connect manually from the shell/a script with `Network::WiFi.connect_timeout(ssid, password,
+   auth, timeout)`. Either way, wait until `Network::WiFi.link_connected?` is true before opening
+   the DAP port — the network stack isn't up until then.
+
+3. Call `Debugger.listen_dap(port)` **before** the first `binding.debugger` call, then hit that
+   breakpoint as usual:
+
+   ```ruby
+   require 'debug'
+   Debugger.listen_dap(4711)
+   binding.debugger
+   ```
+
+   See [`storage/home/dap_debug_sample.rb`](storage/home/dap_debug_sample.rb) for a full example
+   that waits for the WiFi link before opening the DAP port. Copy it (or its content) into your
+   own `/home` script via the [R2P2 Web Terminal](https://picoruby.org/terminal)'s File Editor, or
+   have it built into the storage image (it's already placed under `storage/home/`, which
+   `rake build` packages into `storage.bin`).
+
+4. From your editor's DAP client, attach to `<device IP>:<port>` (e.g. `192.168.1.42:4711`). Find
+   the device's IP via `ESP32::WiFi.tcpip_link_status_name` output on the console, or your
+   router's DHCP lease list.
+
+`Debugger.listen_dap` only takes effect for the very next `binding.debugger` call — see
+picoruby-debug's own README for the full protocol/command reference and POSIX-side testing
+instructions.
+
 ### Flash and Monitor
 
 Flash the built image to your device:

--- a/components/picoruby-esp32/build_config/riscv-esp-picoruby.rb
+++ b/components/picoruby-esp32/build_config/riscv-esp-picoruby.rb
@@ -77,4 +77,8 @@ MRuby::CrossBuild.new('esp32-picoruby') do |conf|
   conf.gem core: 'picoruby-net-mqtt'
   conf.gem core: 'picoruby-net-ntp'
   conf.gem core: 'picoruby-adafruit_sk6812'
+
+  # picoruby-debug is mruby-only and requires picoruby-socket (above) to
+  # serve DAP over WiFi; see README.md's "Remote debugging over WiFi" section.
+  conf.gem github: 'yuuu/picoruby-debug', branch: 'main'
 end

--- a/components/picoruby-esp32/build_config/xtensa-esp-picoruby.rb
+++ b/components/picoruby-esp32/build_config/xtensa-esp-picoruby.rb
@@ -68,4 +68,8 @@ MRuby::CrossBuild.new('esp32-picoruby') do |conf|
   conf.gem core: 'picoruby-net-mqtt'
   conf.gem core: 'picoruby-net-ntp'
   conf.gem core: 'picoruby-adafruit_sk6812'
+
+  # picoruby-debug is mruby-only and requires picoruby-socket (above) to
+  # serve DAP over WiFi; see README.md's "Remote debugging over WiFi" section.
+  conf.gem github: 'yuuu/picoruby-debug', branch: 'main'
 end

--- a/storage/home/dap_debug_sample.rb
+++ b/storage/home/dap_debug_sample.rb
@@ -1,0 +1,85 @@
+# dap_debug_sample.rb
+#
+# Shows how to start picoruby-debug's DAP server on ESP32 once WiFi is up,
+# so an editor (VS Code, Zed, ...) can attach to it as a remote debugger.
+#
+# Prerequisites:
+#   - Firmware built with USE_WIFI=1 and the PicoRuby (mruby) VM, i.e.
+#       USE_WIFI=1 rake picoruby:build
+#     See README.md, "Enabling WiFi (USE_WIFI)" and
+#     "Remote debugging over WiFi (DAP)".
+#   - The picoruby-debug gem must be in the build config (already added to
+#     components/picoruby-esp32/build_config/xtensa-esp-picoruby.rb /
+#     riscv-esp-picoruby.rb).
+#
+# Run this from the picoruby-shell prompt:
+#   $> ./dap_debug_sample.rb
+#
+# This script blocks at `binding.debugger` until a DAP client (an editor)
+# connects and completes its handshake, then behaves like a normal
+# breakpoint from then on.
+
+require 'debug'
+require 'network'
+
+DAP_PORT = 4711
+
+# --- 1. Make sure WiFi is connected before opening the DAP port ---
+#
+# If /etc/network/wifi.yml has `auto_connect: true` (see
+# `rake gen_wifi_config`), main_task.rb has already connected by the time
+# the shell prompt appears, so this block is skipped. Otherwise, fall back
+# to a manual connect using WIFI_SSID / WIFI_PASSWORD from the environment.
+unless Network::WiFi.link_connected?
+  ssid = ENV['WIFI_SSID']
+  password = ENV['WIFI_PASSWORD']
+  unless ssid
+    puts "WiFi is not connected and WIFI_SSID is not set. Aborting."
+    puts "Set up storage/etc/network/wifi.yml (rake gen_wifi_config), or"
+    puts "export WIFI_SSID / WIFI_PASSWORD before running this script."
+    return
+  end
+
+  puts "WiFi not connected yet, connecting to #{ssid}..."
+  Network::WiFi.init("JP") unless Network::WiFi.initialized?
+  Network::WiFi.enable_sta_mode
+
+  auth = password && !password.empty? ? Network::WiFi::Auth::WPA2_MIXED_PSK : Network::WiFi::Auth::OPEN
+  begin
+    connected = Network::WiFi.connect_timeout(ssid, password, auth, 10) # seconds
+    unless connected
+      puts "Failed to connect to WiFi. Aborting."
+      return
+    end
+  rescue Network::ConnectTimeout
+    puts "WiFi connection timed out. Aborting."
+    return
+  end
+
+  until Network::WiFi.link_connected?
+    sleep_ms 100
+  end
+end
+
+puts "WiFi connected (#{Network::WiFi.tcpip_link_status_name})"
+
+# --- 2. Open the DAP port *before* the first binding.debugger call ---
+#
+# Debugger.listen_dap only takes effect for the *next* binding.debugger
+# call (see picoruby-debug's mrblib/debugger.rb: the DAP session is
+# created inside Debugger#initialize, which the first binding.debugger
+# call triggers). Calling it after the breakpoint has already fired is
+# too late.
+Debugger.listen_dap(DAP_PORT)
+puts "DAP server will listen on port #{DAP_PORT} once binding.debugger runs."
+puts "Attach your editor's DAP client to <this device's IP>:#{DAP_PORT}."
+puts "(check the device's IP with: ESP32::WiFi.tcpip_link_status_name, or"
+puts "your router's DHCP lease list)"
+
+# --- 3. A tiny program to debug, with a breakpoint ---
+def add(a, b)
+  a + b
+end
+
+binding.debugger # blocks here until a DAP client completes the handshake
+puts add(1, 2)


### PR DESCRIPTION
## Summary

Part of the DAP remote-debugging implementation plan, **Phase 5b**. Stacked on top of **#158** (Phase 5a, `dap/05a-use-wifi-verification`) — depends on it and should be reviewed/merged after it.

**Add picoruby-debug gem to ESP32 mruby build configs** (85048bf):
- The prior Phase 5 planning assumed `conf.gem github: 'yuuu/picoruby-debug', branch: 'main'` was already present in `xtensa-esp-picoruby.rb`, but neither that file nor `riscv-esp-picoruby.rb` actually declared it (an earlier experimental attempt on a separate, non-merged branch did, but that never landed on this history). Without this, `require 'debug'` has nothing to load on ESP32 regardless of `USE_WIFI`.
- `picoruby-debug` is mruby-only, so it's added to the two mruby VM (PicoRuby) build configs only, not the femtoruby (mruby/c) ones. `picoruby-socket`, its soft dependency for DAP-over-WiFi, is already present in both files.

**Document WiFi-based DAP remote debugging and add a sample script** (98d1322):
- Adds a "Remote debugging over WiFi (DAP)" section to `README.md` covering the end-to-end flow: build with `USE_WIFI=1` + the PicoRuby (mruby) VM, connect to WiFi, call `Debugger.listen_dap(port)` before the first `binding.debugger`, then attach an editor's DAP client to `<device IP>:port`.
- Adds `storage/home/dap_debug_sample.rb`, a runnable example that waits for `Network::WiFi.link_connected?` before opening the DAP port — `listen_dap` only takes effect for the *next* `binding.debugger` call, so getting this ordering right matters. `storage/home/*` is gitignored by default (it's the writable user directory baked into `storage.bin`), so this one file is carved out via a `.gitignore` exception, same pattern as `storage/home/.keep`.

## Test plan

**⚠️ Not verified on real hardware.** Per the implementing agent's commit messages:

- [x] `dap_debug_sample.rb` checked with `ruby -c` and the vendored picoruby's host `mrbc -c` for syntax only.
- [ ] **Not flashed or run on hardware.**
- [ ] **Not built on a real ESP32 target** (the `picoruby-debug` gem addition to the build configs has not been exercised through an actual `rake build`/link on device).
- [ ] End-to-end DAP-over-WiFi session (editor DAP client ↔ device) not exercised.

🤖 Generated with [Claude Code](https://claude.com/claude-code)