### PR TITLE
Update picoruby submodule and fix ESP32 mruby build(2026-07-28)

### DIFF
--- a/components/picoruby-esp32/CMakeLists.txt
+++ b/components/picoruby-esp32/CMakeLists.txt
@@ -11,6 +11,7 @@ if(${PICORB_VM} STREQUAL "mruby")
   set(ADDITIONAL_INCLUDE_DIRS
     ${COMPONENT_DIR}/picoruby/build/esp32-picoruby/include
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mruby/lib/mruby/include
+    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mruby/lib/mruby/mrbgems/mruby-task/include
   )
   set(ADDITIONAL_DEFINITIONS
     -DMRB_TICK_UNIT=10
@@ -22,6 +23,9 @@ if(${PICORB_VM} STREQUAL "mruby")
     -DPICORB_ALLOC_ESTALLOC
     -DPICORB_ALLOC_ALIGN=8
     -DPICORB_VM_MRUBY
+  )
+  set(ADDITIONAL_SRCS
+    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mruby/ports/esp32/task.c
   )
 else()
   file(MAKE_DIRECTORY ${COMPONENT_DIR}/picoruby/build/esp32-femtoruby/mrbgems)
@@ -38,6 +42,7 @@ else()
     -DMRC_CUSTOM_ALLOC
     -DPICORB_VM_MRUBYC
   )
+  set(ADDITIONAL_SRCS "")
 endif()
 
 if(CONFIG_ESP_WIFI_ENABLED AND DEFINED ENV{USE_WIFI})
@@ -56,6 +61,7 @@ endif()
 idf_component_register(
   SRCS
     ${COMPONENT_DIR}/picoruby-esp32.c
+    ${ADDITIONAL_SRCS}
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-esp32/ports/esp32.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-machine/ports/esp32/machine.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-machine/ports/common/machine.c

--- a/components/picoruby-esp32/CMakeLists.txt
+++ b/components/picoruby-esp32/CMakeLists.txt
@@ -60,7 +60,6 @@ idf_component_register(
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-machine/ports/esp32/machine.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-machine/ports/common/machine.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-io-console/ports/esp32/io-console.c
-    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-filesystem-fat/ports/esp32/flash_disk.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-littlefs/ports/esp32/flash_hal.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-env/ports/esp32/env.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-gpio/ports/esp32/gpio.c
@@ -92,7 +91,6 @@ idf_component_register(
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-machine/include
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mbedtls/include
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-mbedtls/lib/mbedtls/include
-    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-filesystem-fat/ports/esp32
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-littlefs/ports/esp32
     ${COMPONENT_DIR}/picoruby/mrbgems/mruby-compiler/include
     ${COMPONENT_DIR}/picoruby/mrbgems/mruby-compiler/lib/prism/include


### PR DESCRIPTION
Building against the latest picoruby caused a build error. There were two causes:

- A reference to `picoruby-filesystem-fat`, which is no longer used, was still left in CMakeLists.txt
- picoruby added a function that each MCU is expected to provide, and the ESP32-side implementation was missing ( https://github.com/picoruby/picoruby/pull/473 )

This PR addresses both issues.
