### PR TITLE
Add picoruby-irq

### DIFF
--- a/components/picoruby-esp32/CMakeLists.txt
+++ b/components/picoruby-esp32/CMakeLists.txt
@@ -23,6 +23,7 @@ if(${PICORB_VM} STREQUAL "mruby")
     -DPICORB_ALLOC_ESTALLOC
     -DPICORB_ALLOC_ALIGN=8
     -DPICORB_VM_MRUBY
+    -DMRB_USE_TASK_SCHEDULER
   )
 else()
   file(MAKE_DIRECTORY ${COMPONENT_DIR}/picoruby/build/esp32-femtoruby/mrbgems)
@@ -66,6 +67,7 @@ idf_component_register(
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-littlefs/ports/esp32/flash_hal.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-env/ports/esp32/env.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-gpio/ports/esp32/gpio.c
+    ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-irq/ports/esp32/irq.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-adc/ports/esp32/adc.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-spi/ports/esp32/spi.c
     ${COMPONENT_DIR}/picoruby/mrbgems/picoruby-rng/ports/esp32/rng.c

--- a/components/picoruby-esp32/build_config/riscv-esp-femtoruby.rb
+++ b/components/picoruby-esp32/build_config/riscv-esp-femtoruby.rb
@@ -39,6 +39,7 @@ MRuby::CrossBuild.new("esp32-femtoruby") do |conf|
   conf.gem core: 'picoruby-adc'
   conf.gem core: 'picoruby-uart'
   conf.gem core: 'picoruby-pwm'
+  conf.gem core: 'picoruby-irq'
 
   # others
   conf.gem core: 'picoruby-esp32'

--- a/components/picoruby-esp32/build_config/riscv-esp-picoruby.rb
+++ b/components/picoruby-esp32/build_config/riscv-esp-picoruby.rb
@@ -68,6 +68,7 @@ MRuby::CrossBuild.new('esp32-picoruby') do |conf|
   conf.gem core: 'picoruby-adc'
   conf.gem core: 'picoruby-uart'
   conf.gem core: 'picoruby-pwm'
+  conf.gem core: 'picoruby-irq'
 
   # others
   conf.gem core: 'picoruby-rmt'

--- a/components/picoruby-esp32/build_config/xtensa-esp-femtoruby.rb
+++ b/components/picoruby-esp32/build_config/xtensa-esp-femtoruby.rb
@@ -39,6 +39,7 @@ MRuby::CrossBuild.new("esp32-femtoruby") do |conf|
   conf.gem core: 'picoruby-adc'
   conf.gem core: 'picoruby-uart'
   conf.gem core: 'picoruby-pwm'
+  conf.gem core: 'picoruby-irq'
 
   # others
   conf.gem core: 'picoruby-esp32'

--- a/components/picoruby-esp32/build_config/xtensa-esp-picoruby.rb
+++ b/components/picoruby-esp32/build_config/xtensa-esp-picoruby.rb
@@ -59,6 +59,7 @@ MRuby::CrossBuild.new('esp32-picoruby') do |conf|
   conf.gem core: 'picoruby-adc'
   conf.gem core: 'picoruby-uart'
   conf.gem core: 'picoruby-pwm'
+  conf.gem core: 'picoruby-irq'
 
   # others
   conf.gem core: 'picoruby-rmt'


### PR DESCRIPTION
Enable the `picoruby-irq` gem in all four ESP32 build configs (xtensa/riscv × picoruby/femtoruby)
Compile the gem's ESP32 port, `picoruby-irq/ports/esp32/irq.c`, as part of the `picoruby-esp32` IDF component
Define `MRB_USE_TASK_SCHEDULER` for the mruby (`PICORB_VM=mruby`) branch of that component